### PR TITLE
fixed conditional evaluation in getGenericTypeBody 

### DIFF
--- a/src/com/hms/flexyosisoftconnector/PayloadBuilder.java
+++ b/src/com/hms/flexyosisoftconnector/PayloadBuilder.java
@@ -313,7 +313,7 @@ public class PayloadBuilder {
     String formatString = "";
 
     // include format if not booleans or strings
-    if (!type.equalsIgnoreCase("string") || !type.equalsIgnoreCase("boolean")) {
+    if (!(type.equalsIgnoreCase("string") || type.equalsIgnoreCase("boolean"))) {
       formatString = "\"format\": \"" + format + "\",";
     }
 


### PR DESCRIPTION
In getGenericcTypeBody, only add extra format key if type is not 'boolean' or 'string'. Resolve issue where if expression always evaluates to true.